### PR TITLE
[ISSUE-6] Fix NotFoundException for older SDK versions

### DIFF
--- a/app/src/main/kotlin/org/bandev/buddhaquotes/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/org/bandev/buddhaquotes/ui/theme/Theme.kt
@@ -1,10 +1,13 @@
 package org.bandev.buddhaquotes.ui.theme
 
+import android.os.Build
 import androidx.compose.animation.core.Spring
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
@@ -16,10 +19,13 @@ fun BuddhaQuotesTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colorScheme = if (darkTheme) {
-        dynamicDarkColorScheme(LocalContext.current)
-    } else {
-        dynamicLightColorScheme(LocalContext.current)
+    val isDynamicColorSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+    val colorScheme = when {
+        isDynamicColorSupported && darkTheme -> dynamicDarkColorScheme(LocalContext.current)
+        isDynamicColorSupported && !darkTheme -> dynamicLightColorScheme(LocalContext.current)
+        darkTheme -> darkColorScheme()
+        else -> lightColorScheme()
     }
 
     MaterialTheme(colorScheme = colorScheme, content = content)


### PR DESCRIPTION
Running the app on SDK version smaller then 12 (API level 31) would cause a crash at the splash screen.

Changes:
- Added SDK version verification at BuddhaQuotesTheme function
- Apply the correct theme colors based on if dynamic colors are supported on the running version